### PR TITLE
Feature/change map ar UI

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -53,6 +53,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
-    
+    <key>WKAppBoundDomains</key>
+    <array>
+      <string>map-viewer.situm.com</string>
+    </array>
 </dict>
 </plist>

--- a/example/lib/config.dart.example
+++ b/example/lib/config.dart.example
@@ -2,3 +2,5 @@ const situmUser = "***";
 const situmApiKey = "***";
 const buildingIdentifier = "***";
 const remoteIdentifier = null;
+const viewerDomain = "https://map-viewer.situm.com";
+const apiDomain = "https://dashboard.situm.com";

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -100,6 +100,7 @@ class _NavigationBaseState extends State<NavigationBase> {
       body: SafeArea(
         child: ARWidget(
           buildingIdentifier: buildingIdentifier,
+          apiDomain: apiDomain,
           onCreated: onUnityViewCreated,
           onPopulated: onUnityViewPopulated,
           onDisposed: onUnityViewDisposed,
@@ -112,8 +113,8 @@ class _NavigationBaseState extends State<NavigationBase> {
               situmApiKey: situmApiKey,
               // Set your building identifier:
               buildingIdentifier: buildingIdentifier,
-              viewerDomain: "https://map-viewer.situm.com",
-              apiDomain: "https://dashboard.situm.com",
+              viewerDomain: viewerDomain,
+              apiDomain: apiDomain,
               remoteIdentifier: remoteIdentifier,
               persistUnderlyingWidget: true,
             ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -103,6 +103,7 @@ class _NavigationBaseState extends State<NavigationBase> {
           onCreated: onUnityViewCreated,
           onPopulated: onUnityViewPopulated,
           onDisposed: onUnityViewDisposed,
+          debugMode: true,
           mapView: MapView(
             key: const Key("situm_map"),
             configuration: MapViewConfiguration(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,10 +2,10 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:situm_flutter_ar/ar.dart';
 import 'package:situm_ar_example/config.dart';
 import 'package:situm_flutter/sdk.dart';
 import 'package:situm_flutter/wayfinding.dart';
+import 'package:situm_flutter_ar/ar.dart';
 
 void main() => runApp(const NavigationBarApp());
 
@@ -97,26 +97,27 @@ class _NavigationBaseState extends State<NavigationBase> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: ARWidget(
-        buildingIdentifier: buildingIdentifier,
-        onCreated: onUnityViewCreated,
-        onPopulated: onUnityViewPopulated,
-        onDisposed: onUnityViewDisposed,
-        arHeightRatio: 0.999,
-        mapView: MapView(
-          key: const Key("situm_map"),
-          configuration: MapViewConfiguration(
-            // Your Situm credentials.
-            // Copy config.dart.example if you haven't already.
-            situmApiKey: situmApiKey,
-            // Set your building identifier:
-            buildingIdentifier: buildingIdentifier,
-            viewerDomain: "https://map-viewer.situm.com",
-            apiDomain: "https://dashboard.situm.com",
-            remoteIdentifier: remoteIdentifier,
-            persistUnderlyingWidget: true,
+      body: SafeArea(
+        child: ARWidget(
+          buildingIdentifier: buildingIdentifier,
+          onCreated: onUnityViewCreated,
+          onPopulated: onUnityViewPopulated,
+          onDisposed: onUnityViewDisposed,
+          mapView: MapView(
+            key: const Key("situm_map"),
+            configuration: MapViewConfiguration(
+              // Your Situm credentials.
+              // Copy config.dart.example if you haven't already.
+              situmApiKey: situmApiKey,
+              // Set your building identifier:
+              buildingIdentifier: buildingIdentifier,
+              viewerDomain: "https://map-viewer.situm.com",
+              apiDomain: "https://dashboard.situm.com",
+              remoteIdentifier: remoteIdentifier,
+              persistUnderlyingWidget: true,
+            ),
+            onLoad: onMapViewLoad,
           ),
-          onLoad: onMapViewLoad,
         ),
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -237,7 +237,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   situm_flutter_unity:
     dependency: "direct main"
     description:

--- a/lib/situm_ar.dart
+++ b/lib/situm_ar.dart
@@ -115,7 +115,6 @@ class _ARWidgetState extends State<ARWidget> {
                   // as it will not animate changes on a child.
                   duration: animationDuration,
                   curve: Curves.decelerate,
-                  // Add SizedBox to set the "visible map" height.
                   height: visibleMapHeight,
                   child: SingleChildScrollView(
                     // Add ScrollView to center the map: TODO fix MapView resizing on iOS.

--- a/lib/situm_ar.dart
+++ b/lib/situm_ar.dart
@@ -97,39 +97,39 @@ class _ARWidgetState extends State<ARWidget> {
         // ============== MapView ==============================================
         Align(
           alignment: Alignment.bottomCenter,
-          child: AnimatedSize(
-            duration: animationDuration,
-            child: LayoutBuilder(
-              // Let us know about the container's height.
-              builder: (BuildContext context, BoxConstraints constraints) {
-                double visibleMapHeight = isArVisible
-                    // If the AR is visible, make the MapView height depend on the
-                    // state collapsed/expanded:
-                    ? (isMapCollapsed
-                        ? 0
-                        : constraints.maxHeight * (1 - widget.arHeightRatio))
-                    // If the AR is not visible, make the MapView full height:
-                    : constraints.maxHeight;
-
-                return AbsorbPointer(
-                  absorbing: isArVisible,
-                  child: SizedBox(
-                    // Add SizedBox to set the "visible map" height.
-                    height: visibleMapHeight,
-                    child: SingleChildScrollView(
-                      // Add ScrollView to center the map: TODO fix MapView resizing on iOS.
-                      controller: scrollController,
-                      physics: const NeverScrollableScrollPhysics(),
-                      child: SizedBox(
-                        // Set the map height equals to the container.
-                        height: constraints.maxHeight,
-                        child: widget.mapView!,
-                      ),
+          child: LayoutBuilder(
+            // Let us know about the container's height.
+            builder: (BuildContext context, BoxConstraints constraints) {
+              double visibleMapHeight = isArVisible
+                  // If the AR is visible, make the MapView height depend on the
+                  // state collapsed/expanded:
+                  ? (isMapCollapsed
+                      ? 0
+                      : constraints.maxHeight * (1 - widget.arHeightRatio))
+                  // If the AR is not visible, make the MapView full height:
+                  : constraints.maxHeight;
+              return AbsorbPointer(
+                absorbing: isArVisible,
+                child: AnimatedContainer(
+                  // NOTE: visibleMapHeight must be a property of AnimatedContainer
+                  // as it will not animate changes on a child.
+                  duration: animationDuration,
+                  curve: Curves.decelerate,
+                  // Add SizedBox to set the "visible map" height.
+                  height: visibleMapHeight,
+                  child: SingleChildScrollView(
+                    // Add ScrollView to center the map: TODO fix MapView resizing on iOS.
+                    controller: scrollController,
+                    physics: const NeverScrollableScrollPhysics(),
+                    child: SizedBox(
+                      // Set the map height equals to the container.
+                      height: constraints.maxHeight,
+                      child: widget.mapView!,
                     ),
                   ),
-                );
-              },
-            ),
+                ),
+              );
+            },
           ),
         ),
         // ============== Expand/collapse AR ===================================

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -236,3 +236,18 @@ class _AmbienceSelectorState extends State<_AmbienceSelector> {
     );
   }
 }
+
+String _validateApiDomain(String apiDomain) {
+  if (!apiDomain.startsWith('http://') && !apiDomain.startsWith('https://')) {
+    apiDomain = 'https://$apiDomain';
+  }
+  Uri? uri = Uri.tryParse(apiDomain);
+  if (uri == null || !uri.isAbsolute) {
+    throw ArgumentError(
+        'Incorrect configuration: apiDomain ($apiDomain) must be a valid URL.');
+  }
+  if (apiDomain.endsWith("/")) {
+    apiDomain = apiDomain.substring(0, apiDomain.length - 1);
+  }
+  return apiDomain;
+}

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -207,7 +207,10 @@ class _AmbienceSelectorState extends State<_AmbienceSelector> {
                   ),
                   isSelected: _enjoySelected,
                   children: [
-                    Text("Enjoy".toUpperCase()),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(6, 0, 6, 0),
+                      child: Text("Enjoy".toUpperCase()),
+                    ),
                   ],
                 ),
               ),

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -95,6 +95,21 @@ Widget _createTempBackButton(VoidCallback onPressed) {
       ));
 }
 
+Widget _createDebugModeSwitchButton(VoidCallback onPressed) {
+  return Align(
+    alignment: Alignment.bottomLeft,
+    child: SizedBox(
+      height: 32,
+      width: 32,
+      child: FloatingActionButton(
+          onPressed: onPressed,
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black54,
+          child: const Icon(Icons.camera_outlined)),
+    ),
+  );
+}
+
 class _AmbienceSelector extends StatefulWidget {
   final Function(int ambience) onAmbienceSelected;
   final Function(bool enjoyEnabled) onEnjoyToggle;


### PR DESCRIPTION
Modified the integration style with the MapView, creating a combined view for AR-MapView.
When the AR button is pressed on the MapView, the combined AR-MapView view opens, which has a new button that allows collapsing the MapView (AR-only view) or expanding it to its maximum limit (combined view).
In this new view, the MapView automatically centers the user position (followUser) and does not accept user events.
The plugin has been modified to exit the AR view on navigation ending (either due to cancellation or reaching the destination). This allows exiting AR when an OOB is obtained or when the integrator cancels the route programmatically.